### PR TITLE
Fix "cannot borrow `*self` as mutable" in reginfixexp

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,6 +11,7 @@ pub struct InfOpr {
     opr: String,
 }
 
+#[derive(Clone)]
 pub struct Parser {
     pub infix: Vec<InfOpr>,
 }

--- a/src/parser/cons.rs
+++ b/src/parser/cons.rs
@@ -24,7 +24,7 @@ impl Parser {
     pub fn cons(&self) -> impl FnMut(&str) -> IResult<&str, Cons, VerboseError<&str>> + '_ {
         |s: &str| alt((self.real(), self.string()))(s)
     }
-    pub fn real(&self) -> impl FnMut(&str) -> IResult<&str, Cons, VerboseError<&str>> + '_ {
+    pub fn real<'a>(&self) -> impl FnMut(&'a str) -> IResult<&'a str, Cons, VerboseError<&'a str>> + 'a {
         |s: &str| map(double, |number: f64| -> Cons { Cons::Real(number) })(s)
     }
     pub fn string(&self) -> impl FnMut(&str) -> IResult<&str, Cons, VerboseError<&str>> + '_ {

--- a/src/parser/exp.rs
+++ b/src/parser/exp.rs
@@ -97,14 +97,16 @@ impl Parser {
     pub fn reginfixexp(
         &mut self,
     ) -> impl FnMut(&str) -> IResult<&str, Exp, VerboseError<&str>> + '_ {
-        |s: &str| {
+        let clone = self.clone();
+        move |s: &str| {
+            let ident_exept_infopr = clone.ident_except_infopr();
             map(
                 tuple((
                     tag(define::INFIX),
                     multispace1,
                     self.real(),
                     multispace1,
-                    self.ident_except_infopr(),
+                    ident_exept_infopr,
                 )),
                 |(_, _, d, _, identifier)| {
                     match d {


### PR DESCRIPTION
Fixes: https://twitter.com/cordx56/status/1476793180733734918
